### PR TITLE
feat: add register L1 block for easier event scanning

### DIFF
--- a/src/KeyManager.sol
+++ b/src/KeyManager.sol
@@ -31,6 +31,8 @@ contract KeyManager is Initializable, OwnableUpgradeable, UUPSUpgradeable {
         uint64 id;
         /// @notice wall clock time since unix epoch for this committee to be active
         uint64 effectiveTimestamp;
+        /// @notice block number of the block in which this committee is registered
+        uint256 registeredBlockNumber;
         /// @notice constituting members and their key materials
         CommitteeMember[] members;
     }
@@ -194,8 +196,12 @@ contract KeyManager is Initializable, OwnableUpgradeable, UUPSUpgradeable {
 
         if (nextCommitteeId == type(uint64).max) revert CommitteeIdOverflow();
 
-        committees[nextCommitteeId] =
-            Committee({id: nextCommitteeId, effectiveTimestamp: effectiveTimestamp, members: members});
+        committees[nextCommitteeId] = Committee({
+            id: nextCommitteeId,
+            effectiveTimestamp: effectiveTimestamp,
+            registeredBlockNumber: block.number,
+            members: members
+        });
 
         nextCommitteeId++;
 

--- a/test/KeyManager.t.sol
+++ b/test/KeyManager.t.sol
@@ -1,7 +1,7 @@
     // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test, console} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {KeyManager} from "../src/KeyManager.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";


### PR DESCRIPTION
Part of https://github.com/EspressoSystems/timeboost/pull/502#discussion_r2362412939

### This PR:

Add an additional `block.number` during `setNextcommittee` registration, so that future committee know where to start syncing for the the new committee events. 
